### PR TITLE
Solve #37 1181 단어정렬

### DIFF
--- a/problems/1181/21400564.py
+++ b/problems/1181/21400564.py
@@ -1,0 +1,17 @@
+import sys
+
+N = int(sys.stdin.readline())
+L = []
+
+for i in range(N):
+  L.append(sys.stdin.readline()[:-1])
+
+L = sorted(L)
+L = sorted(L, key=lambda x : len(x))
+
+last_word = ''
+for i in L :
+  if last_word != i :
+    print(i)
+
+  last_word = i


### PR DESCRIPTION
input이 느리다고 해서
sys.stdin.readline()을 쓰는 중인데
스트링은 '\n' 까지 다 받아와지네요ㅠ

sys.stdin.readline()[:-1] 

으로 \n 제거했습니다. 